### PR TITLE
corrijo error al crear insumo y eliminar insumo

### DIFF
--- a/src/actions/newInsumoAction.js
+++ b/src/actions/newInsumoAction.js
@@ -46,7 +46,7 @@ export const setInsumoToUpdate = ( insumoId ) => ( dispatch, rootState ) => {
 
     const insumos = isEmpty( rootState().insumos )
         ? getFromLocalStorage( type.localStorage.insumos )
-        : rootState().insumos;
+        : rootState().insumos.data;
 
     const insumoToUpdate = find(
         equality( 'id', insumoId ),
@@ -63,22 +63,30 @@ export const startCreateInsumo = ( isSelected ) => async ( dispatch, rootState )
 
     const localInsumos = getFromLocalStorage( type.localStorage.insumos ) || [];
 
-    const { newInsumo: { data }, insumos } = rootState();
+    const { newInsumo: { data }, insumos: { data: insumos } } = rootState();
     const allInsumos = isEmpty( insumos ) ? localInsumos : insumos;
 
     try {
         
         const response = await fetchCreateInsumo( data );
 
-        const insumoCreated = setNewProperty('selected', !!isSelected, response.data );
-        dispatch( addInsumoToState( insumoCreated ) );
-        setInLocalStorage( type.localStorage.insumos, [insumoCreated, ...allInsumos] );
+        if ( response.ok ) {
 
-        NotificationSuccess( type.notificationMessages.newInsumoCreated );
+            const insumoCreated = setNewProperty('selected', !!isSelected, response.data );
+            dispatch( addInsumoToState( insumoCreated ) );
+            setInLocalStorage( type.localStorage.insumos, [insumoCreated, ...allInsumos] );
+    
+            NotificationSuccess( type.notificationMessages.newInsumoCreated );
+    
+            dispatch ( resetForm() );
+    
+            removeFromLocalStorage( type.localStorage.establishments );
 
-        dispatch ( resetForm() );
+        } else {
+            NotificationError( type.notificationMessages.newInsumoCreatedError );
+            NotificationError( response.msg );
+        }
 
-        removeFromLocalStorage( type.localStorage.establishments );
 
     } catch (error) {
 

--- a/src/components/Insumos/InsumoActions.js
+++ b/src/components/Insumos/InsumoActions.js
@@ -6,8 +6,8 @@ import { startDeletingInsumos } from '../../actions/insumosAction';
 import { setInsumoToUpdate } from '../../actions/newInsumoAction';
 import { removeInsumoFromPurchase } from '../../actions/newPurchaseAction';
 
-import { detalleInsumoPath, editarInsumoPath } from '../../constant/routes';
-import { EditButton, LeftCircleButton, SeeDetailsButton, TrashButton } from '../Buttons/AppButtons';
+import { editarInsumoPath } from '../../constant/routes';
+import { EditButton, LeftCircleButton, TrashButton } from '../Buttons/AppButtons';
 
 export const InsumoBaseActions = React.memo( ({ id }) => {
 
@@ -19,23 +19,21 @@ export const InsumoBaseActions = React.memo( ({ id }) => {
 
     // ===== STATE =====
     const [toogle, setToogle] = useState(false);
-    // const [insumoDetailsPage, setInsumoDetailsPage] = useState('');
 
     // ===== FUNCIONES PROPIEAS =====
     const handleClickOnActionMenu = useCallback(( ev ) => {
         ev.stopPropagation();
 
         setToogle( s => !s );
-        // setInsumoDetailsPage( `${ detalleInsumoPath }/${ id }` );
 
     },[])
 
-    const handleDeleteInsumo = useCallback(( ev ) => {
+    const handleDeleteInsumo = ( ev ) => {
         ev.stopPropagation();
 
         dispatch( startDeletingInsumos( id ) );
         setToogle( false );
-    },[])
+    }
     
     const handleUpdateInsumo = ( ev ) => {
         ev.stopPropagation();


### PR DESCRIPTION
- Corrijo error al crear insumo. Error frontend que ocurria cuando se usaba el valor erroneo de `insumos` en lugar de `insumos.data`
- Corrijo error al eliminar insumos. Se estaba eliminando el insumo erroneo debido a que la función que ejecuta el `dispatch` estaba dentro de un `useCallback` y por tanto el argumento `id` siempre era el mismo para todos los insumos.