### PR TITLE
elimino funcionalidad de cerrar compra

### DIFF
--- a/src/Pages/PaginaDetalleCompra.js
+++ b/src/Pages/PaginaDetalleCompra.js
@@ -11,7 +11,7 @@ const TWODECIMALS = round( 2 );
 export const PaginaDetalleCompra = ({ details }) => {
 
     // ===== VARIABLES LOCALES =====
-    const { closed, date, establishmentName, insumos, name, total } = details;
+    const { date, establishmentName, insumos, name, total } = details;
     const insumosOrdered = paretoOrdering( insumos, { prop: 'total', total } );
 
     return (
@@ -24,7 +24,6 @@ export const PaginaDetalleCompra = ({ details }) => {
             {date && <Descriptor data={ getFormatDate( date ) } label="Fecha:" userClass="animate__delay-1s" />}
             <div className="flex justify-between items-center">
                 {establishmentName && <Descriptor data={ establishmentName } label="Comprado en:" userClass="animate__delay-2s" />}
-                <Descriptor data={ closed ? 'Cerrada' : 'Abierta' } label="Compra:" userClass="animate__delay-5s" />
             </div>
             <div
                 className="
@@ -65,7 +64,7 @@ const InsumosList = ({ insumos }) => {
                         font-bold text-lime-500
                         bg-lime-50
                         py-2
-                        sticky top-16
+                        sticky -top-4
                     `}
                 >
                     <span

--- a/src/Pages/PaginaResumenCompras.js
+++ b/src/Pages/PaginaResumenCompras.js
@@ -7,13 +7,12 @@ import { ListButton, GalleryButton } from '../components/Buttons/AppButtons';
 import { BigAddButton } from '../components/Buttons/BigAddButton';
 import { ItemList } from '../components/purchases/ItemList';
 import { PurchaseCard } from '../components/purchases/PurchaseCard';
-import { BaseButton } from '../components/Buttons/AppButtons';
 
 import { nuevaCompraPath } from '../constant/routes';
 import { type } from '../constant/type';
 
 import { capitalizeText } from '../helper/capitalize';
-import { getPurchasesByMonth, orderingPurchases } from '../helper/orderingPurchases';
+import { getPurchasesByPeriod } from '../helper/orderingPurchases';
 
 export const PaginaResumenCompras = () => {
 
@@ -46,7 +45,7 @@ const PurchasesList = ({ purchasesList }) => {
     const [period, setPeriod] = useState( type.period.week );
 
     // ===== VARIABLES PROPIAS =====
-    const purchases = getPurchasesByMonth( purchasesList, { period } );
+    const purchases = getPurchasesByPeriod( purchasesList, { period } );
 
     // ===== STORE =====
     const dispatch = useDispatch();

--- a/src/Pages/PaginaResumenCompras.js
+++ b/src/Pages/PaginaResumenCompras.js
@@ -46,8 +46,7 @@ const PurchasesList = ({ purchasesList }) => {
     const [period, setPeriod] = useState( type.period.week );
 
     // ===== VARIABLES PROPIAS =====
-    const purchasesOrdered = orderingPurchases( purchasesList );
-    const purchases = getPurchasesByMonth( purchasesOrdered, { period } );
+    const purchases = getPurchasesByMonth( purchasesList, { period } );
 
     // ===== STORE =====
     const dispatch = useDispatch();

--- a/src/actions/newPurchaseAction.js
+++ b/src/actions/newPurchaseAction.js
@@ -143,6 +143,7 @@ export const startCreatingPurchase = ( history ) => async ( dispatch, rootState 
         dispatch( selectAllInsumosToBuy( false ) );
 
         removeFromLocalStorage( type.localStorage.purchases );
+        removeFromLocalStorage( type.localStorage.insumos );
 
         NotificationSuccess( type.notificationMessages.newPurchaseCreated );
 

--- a/src/actions/purchasesDetailsAction.js
+++ b/src/actions/purchasesDetailsAction.js
@@ -35,32 +35,6 @@ export const startLoadingPurchaseDetails = ( id ) => async ( dispatch ) => {
     }
 }
 
-export const startClosingPurchase = ( purchase ) => async ( dispatch ) => {
-
-    dispatch( startLoading() );
-
-    try {
-
-        const response = await fetchUpdatePurchase( purchase );
-
-        if ( response.ok ) {
-
-            dispatch( unSelectAllPurchases() );
-            dispatch( selectPurchase( response.data ) );
-            removeFromLocalStorage( type.localStorage.purchases );
-        } else {
-
-            NotificationError( response.msg );
-        }
-
-    } catch (error) {
-        NotificationError( type.notificationMessages.purchasesLoadedError );
-        console.log('Error: no fue posible obtener la informacion de la compra');
-    } finally {
-        dispatch( endLoading() );
-    }
-}
-
 export const startDeletingPurchase = ( id ) => async ( dispatch ) => {
 
     dispatch( startLoading() );

--- a/src/components/Container/DetalleCompraContainer.js
+++ b/src/components/Container/DetalleCompraContainer.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { unSelectAllPurchases } from '../../actions/purchasesAction';
-import { startClosingPurchase, startDeletingPurchase, startLoadingPurchaseDetails } from '../../actions/purchasesDetailsAction';
+import { startDeletingPurchase, startLoadingPurchaseDetails } from '../../actions/purchasesDetailsAction';
 import { resumenDeComprasPath } from '../../constant/routes';
 
 import { LoadingPaginaDetalleCompra } from '../../Pages/loading/LoadingPaginaDetalleCompra';
@@ -24,7 +24,6 @@ export const DetalleCompraContainer = () => {
 
     // ===== STATE =====
     const [showDeleting, setShowDeleting] = useState( false );
-    const [showClosing, setShowClosing] = useState( false );
 
     // ===== VARIABLES LOCALES =====
     const purchase = selected[0];
@@ -36,14 +35,6 @@ export const DetalleCompraContainer = () => {
         dispatch( startDeletingPurchase( id ) );
 
         setShowDeleting( false );
-
-    }
-
-    const onClosingPurchase = () => {
-
-        dispatch( startClosingPurchase( { ...purchase, closed: !purchase.closed } ) );
-
-        setShowClosing( false );
 
     }
 
@@ -106,9 +97,7 @@ export const DetalleCompraContainer = () => {
             <PaginaDetalleCompra details={ purchase } />
 
             <DetalleCompraMenuMobile
-                purchaseClosed={ purchase.closed }
                 deleteAction={ () => setShowDeleting( true ) }
-                closingAction={ () => setShowClosing( true ) }
             />
 
             {/* MODALES */}
@@ -119,61 +108,6 @@ export const DetalleCompraContainer = () => {
                 />
             </BottomModal>
 
-            <BottomModal show={ showClosing }>
-                <ConfirmClosingPurchase
-                    close={ () => setShowClosing( false ) }
-                    accept={ onClosingPurchase }
-                    purchaseClosed={ purchase.closed }
-                />
-            </BottomModal>
-        </div>
-    )
-}
-
-const ConfirmClosingPurchase = ({ close, accept, purchaseClosed }) => {
-    return (
-        <div
-            className="
-                mt-4
-            "
-        >
-            <h1
-                className="
-                    text-rose-500 font-semibold text-2xl
-                "
-            > ¿seguro que quiere { purchaseClosed ? 'abrir' : 'cerrar' } esta compra?
-            </h1>
-            <div
-                className="
-                    flex items-center justify-center
-                    mt-8
-                "
-            >
-                <BaseButton
-                    isButton
-                    className="
-                        mx-2 px-2 py-3
-                        w-full
-                        rounded
-                        text-base text-warmgray-800 font-semibold
-                        bg-warmGray-200
-                    "
-                    onClick={ close }
-                >Cancelar
-                </BaseButton>
-                <BaseButton
-                    isButton
-                    className="
-                        mx-2 px-2 py-3
-                        w-full
-                        rounded
-                        text-base text-warmgray-800 font-semibold
-                        bg-white
-                    "
-                    onClick={ accept }
-                >Aceptar
-                </BaseButton>
-            </div>
         </div>
     )
 }

--- a/src/components/Menus/DetalleCompraMenuMobile.js
+++ b/src/components/Menus/DetalleCompraMenuMobile.js
@@ -1,26 +1,15 @@
 import React from 'react';
 
-import { LockButton, LockButtonOpen, TrashButton } from '../Buttons/AppButtons';
+import { TrashButton } from '../Buttons/AppButtons';
 
-export const DetalleCompraMenuMobile = ({ deleteAction, closingAction, purchaseClosed }) => {
+export const DetalleCompraMenuMobile = ({ deleteAction }) => {
     return (
         <div
             className="
                 menu_mobile__container
-                grid-cols-2
+                grid-cols-1
             "
         >
-
-            {purchaseClosed
-                ? <LockButtonOpen
-                    isButton
-                    onClick={ closingAction }
-                />
-                : <LockButton
-                    isButton
-                    onClick={ closingAction }
-                />
-            }
 
             <TrashButton
                 isButton

--- a/src/components/Menus/MisComprasMenuMobile.js
+++ b/src/components/Menus/MisComprasMenuMobile.js
@@ -45,6 +45,7 @@ export const MisComprasMenuMobile = () => {
             className="
                 menu_mobile__container
                 grid-cols-4
+                z-20
             "
         >
 

--- a/src/components/purchases/ItemList.js
+++ b/src/components/purchases/ItemList.js
@@ -36,7 +36,6 @@ export const ItemList = ({ purchase, index, onSelect }) => {
                 "
             >
                 <CheckedCard inline selected={ purchase.selected } />
-                <LockedBuyIcon closed={ purchase.closed } selected={ purchase.selected } />
             </div>
 
             <div

--- a/src/components/purchases/PurchaseCard.js
+++ b/src/components/purchases/PurchaseCard.js
@@ -29,7 +29,6 @@ export const PurchaseCard = ({ purchase, onSelect }) => {
                     flex items-end justify-between
                 "
             >
-                <LockedBuyIcon closed={ purchase.closed } selected={ purchase.selected } />
                 <BuyTotal total={ purchase.total } selected={ purchase.selected } />
             </div>
 

--- a/src/helper/orderingPurchases.js
+++ b/src/helper/orderingPurchases.js
@@ -45,7 +45,7 @@ export const getPurchasesByMonth = (purchases, { period }) => {
         
         const periodName = ( isMonth && dateFormatted + ' - ' + year ) || ( isWeek && `Semana ${dateFormatted} - ${year}` );
 
-        const existIndex = period.findIndex(m => m.number === periodNumber + year);
+        const existIndex = period.findIndex(m => m.name === periodName);
 
         if ( existIndex > -1) {
 

--- a/src/helper/orderingPurchases.js
+++ b/src/helper/orderingPurchases.js
@@ -22,7 +22,7 @@ export const orderingPurchases = ( list ) => {
     return [...purchases[0], ...purchases[1]];
 }
 
-export const getPurchasesByMonth = (purchases, { period }) => {
+export const getPurchasesByPeriod = (purchases, { period }) => {
 
     // ===== MES =====
     const isMonth = period === type.period.month;


### PR DESCRIPTION
- Elimino funcionalidad de *Cerrar / Abrir* compras
- Remuevo insumos del local storage al crear nueva compra
- Filtro compras por tiempo usando el `nombre del periodo` y no el `numero del periodo`
- Elimino icono de candado en tarjeta de compra en pantalla de `resumen de compra`